### PR TITLE
llegir capçaleres en castellà

### DIFF
--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -1,6 +1,6 @@
-import { read, utils } from 'xlsx';
-import { TransportData } from '../types/transport';
-import { ExcelParseError } from '../types/errors';
+import { read, utils } from "xlsx";
+import { TransportData } from "../types/transport";
+import { ExcelParseError } from "../types/errors";
 
 export const parseExcelFile = async (file: File): Promise<TransportData[]> => {
   return new Promise((resolve, reject) => {
@@ -9,44 +9,65 @@ export const parseExcelFile = async (file: File): Promise<TransportData[]> => {
     reader.onload = (e) => {
       try {
         if (!e.target?.result) {
-          throw new ExcelParseError('No s\'ha pogut llegir el fitxer');
+          throw new ExcelParseError("No s'ha pogut llegir el fitxer");
         }
 
         const data = new Uint8Array(e.target.result as ArrayBuffer);
-        const workbook = read(data, { type: 'array' });
-        
+        const workbook = read(data, { type: "array" });
+
         if (!workbook.SheetNames.length) {
-          throw new ExcelParseError('El fitxer Excel està buit');
+          throw new ExcelParseError("El fitxer Excel està buit");
         }
 
         const worksheet = workbook.Sheets[workbook.SheetNames[0]];
-        const jsonData = utils.sheet_to_json(worksheet, { 
+        const jsonData = utils.sheet_to_json(worksheet, {
           header: 1,
           raw: false,
-          blankrows: false
+          blankrows: false,
         });
-
+        console.log("jsonData ", jsonData);
         // Skip empty rows at the beginning
-        const headerRowIndex = jsonData.findIndex((row: any[]) => 
-          row?.some(cell => cell === 'Num.Transacción' || cell === 'Data')
+        const headerRowIndex = jsonData.findIndex((row: any[]) =>
+          row?.some(
+            (cell) =>
+              cell === "NUM. TRANSACCIÓN" ||
+              cell === "Data" ||
+              cell === "Num.Transacción"
+          )
         );
 
         if (headerRowIndex === -1) {
-          throw new ExcelParseError('Format incorrecte: No s\'han trobat les capçaleres esperades');
+          throw new ExcelParseError(
+            "Format incorrecte: No s'han trobat les capçaleres esperades"
+          );
         }
 
         const headers = jsonData[headerRowIndex] as string[];
+        console.log("headers ", headers);
+
         const requiredColumns = {
-          date: headers.indexOf('Data'),
-          agency: headers.indexOf('Agència'),
-          operation: headers.indexOf('Operació'),
-          station: headers.indexOf('Estació Fix')
+          date:
+            headers.indexOf("Data") !== -1
+              ? headers.indexOf("Data")
+              : headers.indexOf("FECHA"),
+          agency:
+            headers.indexOf("Agència") !== -1
+              ? headers.indexOf("Agència")
+              : headers.indexOf("AGENCIA"),
+          operation:
+            headers.indexOf("Operació") !== -1
+              ? headers.indexOf("Operació")
+              : headers.indexOf("OPERACIÓN"),
+          station:
+            headers.indexOf("Estació Fix") !== -1
+              ? headers.indexOf("Estació Fix")
+              : headers.indexOf("ESTACIÓN FIJO"),
         };
 
         // Verify all required columns exist
-        if (Object.values(requiredColumns).some(index => index === -1)) {
+        if (Object.values(requiredColumns).some((index) => index === -1)) {
           throw new ExcelParseError(
-            'Format incorrecte: El fitxer ha de contenir les columnes Data, Agència, Operació i Estació Fix'
+            "Format incorrecte: El fitxer ha de contenir les columnes Data, Agència, Operació i Estació Fix"
           );
         }
 
@@ -57,28 +78,35 @@ export const parseExcelFile = async (file: File): Promise<TransportData[]> => {
           const row = jsonData[i] as any[];
           if (!row || row.length === 0) continue;
 
-          const operation = String(row[requiredColumns.operation] || '').trim();
-          
+          const operation = String(row[requiredColumns.operation] || "").trim();
+
           // Only process "Validació d'entrada" records
-          if (operation.includes('Validació')) {
+          if (operation.includes("Validació")) {
             try {
               const dateStr = row[requiredColumns.date];
               if (!dateStr) continue;
 
               // Parse date in format DD/MM/YYYY HH:mm:ss
-              const [datePart, timePart] = dateStr.split(' ');
-              const [day, month, year] = datePart.split('/').map(Number);
-              const [hours, minutes, seconds] = timePart.split(':').map(Number);
-              
-              const date = new Date(year, month - 1, day, hours, minutes, seconds);
-              
+              const [datePart, timePart] = dateStr.split(" ");
+              const [day, month, year] = datePart.split("/").map(Number);
+              const [hours, minutes, seconds] = timePart.split(":").map(Number);
+
+              const date = new Date(
+                year,
+                month - 1,
+                day,
+                hours,
+                minutes,
+                seconds
+              );
+
               if (isNaN(date.getTime())) {
                 console.warn(`Data invàlida a la fila ${i + 1}: ${dateStr}`);
                 continue;
               }
 
-              const agency = String(row[requiredColumns.agency] || '').trim();
-              const station = String(row[requiredColumns.station] || '').trim();
+              const agency = String(row[requiredColumns.agency] || "").trim();
+              const station = String(row[requiredColumns.station] || "").trim();
 
               if (!agency || !station) {
                 console.warn(`Dades incompletes a la fila ${i + 1}`);
@@ -89,7 +117,7 @@ export const parseExcelFile = async (file: File): Promise<TransportData[]> => {
                 date,
                 agency,
                 station,
-                operation
+                operation,
               });
             } catch (error) {
               console.warn(`Error processant la fila ${i + 1}:`, error);
@@ -98,16 +126,21 @@ export const parseExcelFile = async (file: File): Promise<TransportData[]> => {
         }
 
         if (!transportData.length) {
-          throw new ExcelParseError('No s\'han trobat validacions al fitxer');
+          throw new ExcelParseError("No s'han trobat validacions al fitxer");
         }
 
         resolve(transportData);
       } catch (error) {
-        reject(error instanceof ExcelParseError ? error : new ExcelParseError('Error processant el fitxer'));
+        reject(
+          error instanceof ExcelParseError
+            ? error
+            : new ExcelParseError("Error processant el fitxer")
+        );
       }
     };
 
-    reader.onerror = () => reject(new ExcelParseError('Error llegint el fitxer'));
+    reader.onerror = () =>
+      reject(new ExcelParseError("Error llegint el fitxer"));
     reader.readAsArrayBuffer(file);
   });
 };


### PR DESCRIPTION
Els usuaris que descarregaven l'arxiu Excel des de la pàgina web de t-mobilitat amb l'idioma en castellà en comptes de català, no podien fer servir l'aplicació, ja que les capçaleres de l'arxiu que es descarrega estan en castellà i no en català. Ara la pagina llegeix els 2 tipus de fitxers