### PR TITLE
Heatmap de les validacions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^18.3.1",
         "react-calendar-heatmap": "^1.10.0",
         "react-dom": "^18.3.1",
+        "react-tooltip": "^5.29.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -847,6 +848,31 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.0",
@@ -1833,6 +1859,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/codepage": {
       "version": "1.15.0",
@@ -3339,6 +3371,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.29.1",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.29.1.tgz",
+      "integrity": "sha512-rmJmEb/p99xWhwmVT7F7riLG08wwKykjHiMGbDPloNJk3tdI73oHsVOwzZ4SRjqMdd5/xwb/4nmz0RcoMfY7Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/read-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "transport-wrapped",
       "version": "0.0.0",
       "dependencies": {
+        "@types/react-calendar-heatmap": "^1.9.0",
         "html-to-image": "^1.11.11",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
+        "react-calendar-heatmap": "^1.10.0",
         "react-dom": "^18.3.1",
         "xlsx": "^0.18.5"
       },
@@ -57,13 +59,15 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.25.7",
-        "picocolors": "^1.0.0"
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -193,19 +197,21 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -220,40 +226,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
-      "integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.7",
-        "@babel/types": "^7.25.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.7.tgz",
-      "integrity": "sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.28.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -293,14 +286,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-      "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -334,14 +328,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.7.tgz",
-      "integrity": "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -828,12 +822,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1261,17 +1270,24 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true
+      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="
     },
     "node_modules/@types/react": {
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-calendar-heatmap": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar-heatmap/-/react-calendar-heatmap-1.9.0.tgz",
+      "integrity": "sha512-BH8M/nsXoLGa3hxWbrq3guPwlK0cV+w1i4c/ktrTxTzN5fBths6WbeUZ4dK0+tE76qiGoVSo9Tse8WVVuMIV+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -1427,10 +1443,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1589,18 +1606,6 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1688,10 +1693,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1760,9 +1766,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
       "dev": true,
       "funding": [
         {
@@ -1777,7 +1783,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/cfb": {
       "version": "1.2.2",
@@ -1789,20 +1796,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/chokidar": {
@@ -1849,21 +1842,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1897,10 +1875,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1925,8 +1904,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -2026,15 +2004,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -2503,10 +2472,11 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2543,15 +2513,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -2845,6 +2806,12 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2906,9 +2873,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -2916,6 +2883,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2957,7 +2925,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3083,10 +3050,11 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3282,6 +3250,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3322,6 +3301,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-calendar-heatmap": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-calendar-heatmap/-/react-calendar-heatmap-1.10.0.tgz",
+      "integrity": "sha512-e5vcrzMWzKIF710egr1FpjWyuDEFeZm39nvV25muc8Wtqqi8iDOfqREELeQ9Wouqf9hhj939gq0i+iAxo7KdSw==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -3333,6 +3325,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -3658,18 +3656,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -3744,15 +3730,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
@@ -3879,10 +3856,11 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^18.3.1",
     "react-calendar-heatmap": "^1.10.0",
     "react-dom": "^18.3.1",
+    "react-tooltip": "^5.29.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/react-calendar-heatmap": "^1.9.0",
     "html-to-image": "^1.11.11",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
+    "react-calendar-heatmap": "^1.10.0",
     "react-dom": "^18.3.1",
     "xlsx": "^0.18.5"
   },

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -3,7 +3,7 @@ import { TransportSummary } from "../types/transport";
 import { Train, Diamond, TowerControl, Share2 } from "lucide-react";
 import { StatCard } from "./summary/StatCard";
 import { TopList } from "./summary/TopList";
-import ContributionCalendar from "./summary/ContributionCalendar";
+import ValidationsCalendar from "./summary/ValidationsCalendar";
 
 // Lazy load the image export utility
 const exportToImage = lazy(() =>
@@ -85,7 +85,7 @@ export const Summary: React.FC<SummaryProps> = ({ summary }) => {
         </div>
 
         {/* Contribution calendar */}
-        <ContributionCalendar data={summary.validationsByDay} />
+        <ValidationsCalendar data={summary.validationsByDay} />
 
         <div className="mt-12 text-center">
           <p className="text-sm md:text-base font-medium text-gray-500">

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -3,6 +3,7 @@ import { TransportSummary } from "../types/transport";
 import { Train, Diamond, TowerControl, Share2 } from "lucide-react";
 import { StatCard } from "./summary/StatCard";
 import { TopList } from "./summary/TopList";
+import ContributionCalendar from "./summary/ContributionCalendar";
 
 // Lazy load the image export utility
 const exportToImage = lazy(() =>
@@ -82,6 +83,9 @@ export const Summary: React.FC<SummaryProps> = ({ summary }) => {
             />
           </StatCard>
         </div>
+
+        {/* Contribution calendar */}
+        <ContributionCalendar data={summary.validationsByDay} />
 
         <div className="mt-12 text-center">
           <p className="text-sm md:text-base font-medium text-gray-500">

--- a/src/components/summary/ContributionCalendar.tsx
+++ b/src/components/summary/ContributionCalendar.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import CalendarHeatmap from 'react-calendar-heatmap';
+import 'react-calendar-heatmap/dist/styles.css';
+
+// Data point type
+export interface CalendarDay {
+  date: string; // ISO yyyy-MM-dd
+  count: number;
+}
+
+interface ContributionCalendarProps {
+  data: CalendarDay[];
+}
+
+/**
+ * GitHub-style contribution calendar for T-mobilitat validations.
+ * We keep types permissive (`any`) inside callbacks to avoid the generic complexity
+ * of `react-calendar-heatmap`, while still guarding against missing values.
+ */
+const ContributionCalendar: React.FC<ContributionCalendarProps> = ({ data }) => {
+  if (!data || data.length === 0) return null;
+
+  const today = new Date();
+  const lastDateStr = data.reduce((max, d) => (d.date > max ? d.date : max), data[0].date);
+  const lastDate = new Date(lastDateStr);
+  const startDate = new Date(lastDate.getFullYear(), 0, 1);
+
+  const getTooltipDataAttrs = (value: any) => {
+    if (!value || !value.date) return {};
+    const dateObj = new Date(value.date);
+    const dateString = dateObj.toLocaleDateString('ca-ES', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    return {
+      'data-tooltip-id': 'heatmap-tooltip',
+      'data-tooltip-content': `${dateString}: ${value.count} validacions`,
+    };
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-md mt-8">
+      <h3 className="text-xl font-bold mb-4 text-gray-800">Calendari d'ús</h3>
+      <CalendarHeatmap
+        startDate={startDate}
+        endDate={today}
+        values={data as any}
+        classForValue={(value: any) => {
+          if (!value || value.count === 0) return 'color-empty';
+          const level = Math.min(4, value.count); // clamp 0-4
+          return `color-scale-${level}`;
+        }}
+        tooltipDataAttrs={getTooltipDataAttrs}
+        showWeekdayLabels
+      />
+    </div>
+  );
+};
+
+export default ContributionCalendar;

--- a/src/components/summary/ContributionCalendar.tsx
+++ b/src/components/summary/ContributionCalendar.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import CalendarHeatmap from 'react-calendar-heatmap';
+
+import { Tooltip } from 'react-tooltip';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: Type definitions outdated, squareSize not included
+import CalendarHeatmapOriginal from 'react-calendar-heatmap';
+// cast to any to allow custom props like squareSize
+const Heatmap: any = CalendarHeatmapOriginal;
+import { CalendarDays } from 'lucide-react';
 import 'react-calendar-heatmap/dist/styles.css';
 
 // Data point type
@@ -20,41 +27,81 @@ interface ContributionCalendarProps {
 const ContributionCalendar: React.FC<ContributionCalendarProps> = ({ data }) => {
   if (!data || data.length === 0) return null;
 
-  const today = new Date();
-  const lastDateStr = data.reduce((max, d) => (d.date > max ? d.date : max), data[0].date);
+  
+    const lastDateStr = data.reduce((max, d) => (d.date > max ? d.date : max), data[0].date);
+  const firstDateStr = data.reduce((min, d) => (d.date < min ? d.date : min), data[0].date);
   const lastDate = new Date(lastDateStr);
-  const startDate = new Date(lastDate.getFullYear(), 0, 1);
+  const startDate = new Date(firstDateStr);
 
-  const getTooltipDataAttrs = (value: any) => {
-    if (!value || !value.date) return {};
-    const dateObj = new Date(value.date);
-    const dateString = dateObj.toLocaleDateString('ca-ES', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-    return {
-      'data-tooltip-id': 'heatmap-tooltip',
-      'data-tooltip-content': `${dateString}: ${value.count} validacions`,
-    };
+  
+
+  // Determine if range spans multiple years
+  const firstYear = startDate.getFullYear();
+  const lastYear = lastDate.getFullYear();
+  const years: number[] = [];
+  for (let y = firstYear; y <= lastYear; y += 1) years.push(y);
+
+  const renderHeatmap = (year: number) => {
+    const SQUARE = 12;
+    const GUTTER = 3;
+    const yearStart = year === firstYear ? startDate : new Date(year, 0, 1);
+    const yearEnd = year === lastYear ? lastDate : new Date(year, 11, 31);
+    // number of weeks shown (inclusive)
+    const millisInWeek = 1000 * 60 * 60 * 24 * 7;
+    const weeks = Math.ceil((yearEnd.getTime() - yearStart.getTime()) / millisInWeek) + 1;
+    const svgWidth = weeks * (SQUARE + GUTTER);
+    const yearValues = data.filter((d) => new Date(d.date).getFullYear() === year);
+    return (
+      <div key={year} className="mb-8">
+        {years.length > 1 && (
+          <h4 className="text-lg font-semibold text-gray-700 mb-2">{year}</h4>
+        )}
+        
+        <Heatmap
+          squareSize={SQUARE}
+          gutterSize={GUTTER}
+          svgProps={{ width: svgWidth }}
+          
+          showWeekdayLabels
+          weekdayLabels={["Dg", "Dl", "Dt", "Dc", "Dj", "Dv", "Ds"]}
+          monthLabels={["Gen", "Feb", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Oct", "Nov", "Des"]}
+          startDate={yearStart}
+          endDate={yearEnd}
+          values={yearValues as any}
+          
+          tooltipDataAttrs={(value: any) => {
+            if (!value || !value.date) {
+              return { 'data-tooltip-id': 'cal-tip', 'data-tooltip-content': '' };
+            }
+            const dateObj = new Date(value.date);
+            const day = dateObj.getDate();
+            const monthNames = ["gener","febrer","març","abril","maig","juny","juliol","agost","setembre","octubre","novembre","desembre"];
+            const monthName = monthNames[dateObj.getMonth()];
+            const count = value.count || 0;
+            return {
+              'data-tooltip-id': 'cal-tip',
+              'data-tooltip-content': `${count === 0 ? 'Sense validacions' : count + ' validacions'} el ${day} de ${monthName}`,
+            } as { [key: string]: string };
+          }}
+          classForValue={(value: any) => {
+            if (!value || value.count === 0) return 'color-empty';
+            const level = Math.min(4, value.count);
+            return `color-scale-${level}`;
+          }}
+          />
+      </div>
+    );
   };
 
   return (
-    <div className="bg-white p-6 rounded-lg shadow-md mt-8">
-      <h3 className="text-xl font-bold mb-4 text-gray-800">Calendari d'ús</h3>
-      <CalendarHeatmap
-        startDate={startDate}
-        endDate={today}
-        values={data as any}
-        classForValue={(value: any) => {
-          if (!value || value.count === 0) return 'color-empty';
-          const level = Math.min(4, value.count); // clamp 0-4
-          return `color-scale-${level}`;
-        }}
-        tooltipDataAttrs={getTooltipDataAttrs}
-        showWeekdayLabels
-      />
+    <div className="p-8 bg-gradient-to-br from-[#86c04d]/10 to-[#009889]/10 rounded-lg border border-[#86c04d]/20 mt-8">
+      <h3 className="flex items-center space-x-4 mb-6">
+          <CalendarDays className="w-8 h-8 text-[#86c04d]" />
+          <span className="text-xl md:text-2xl font-semibold text-gray-800">Calendari de Validacions</span>
+        </h3>
+      {years.map(renderHeatmap)}
+      <Tooltip id="cal-tip" delayShow={0} />
+
     </div>
   );
 };

--- a/src/components/summary/ValidationsCalendar.tsx
+++ b/src/components/summary/ValidationsCalendar.tsx
@@ -96,11 +96,11 @@ const ValidationsCalendar: React.FC<ValidationsCalendarProps> = ({ data }) => {
   };
 
   return (
-    <div className="p-8 bg-gradient-to-br from-[#86c04d]/10 to-[#009889]/10 rounded-lg border border-[#86c04d]/20 mt-8">
+    <div className="hidden md:block p-8 bg-gradient-to-br from-[#86c04d]/10 to-[#009889]/10 rounded-lg border border-[#86c04d]/20 mt-8">
       <h3 className="flex items-center space-x-4 mb-6">
-          <CalendarDays className="w-8 h-8 text-[#86c04d]" />
-          <span className="text-xl md:text-2xl font-semibold text-gray-800">Calendari de Validacions</span>
-        </h3>
+        <CalendarDays className="w-8 h-8 text-[#86c04d]" />
+        <span className="text-xl md:text-2xl font-semibold text-gray-800">Calendari de Validacions</span>
+      </h3>
       {years.map(renderHeatmap)}
       <Tooltip id="cal-tip" delayShow={0} />
     </div>

--- a/src/components/summary/ValidationsCalendar.tsx
+++ b/src/components/summary/ValidationsCalendar.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from 'react-tooltip';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Type definitions outdated, squareSize not included
 import CalendarHeatmapOriginal from 'react-calendar-heatmap';
-// cast to any to allow custom props like squareSize
+
 const Heatmap: any = CalendarHeatmapOriginal;
 import { CalendarDays } from 'lucide-react';
 import 'react-calendar-heatmap/dist/styles.css';
@@ -15,25 +15,17 @@ export interface CalendarDay {
   count: number;
 }
 
-interface ContributionCalendarProps {
+interface ValidationsCalendarProps {
   data: CalendarDay[];
 }
 
-/**
- * GitHub-style contribution calendar for T-mobilitat validations.
- * We keep types permissive (`any`) inside callbacks to avoid the generic complexity
- * of `react-calendar-heatmap`, while still guarding against missing values.
- */
-const ContributionCalendar: React.FC<ContributionCalendarProps> = ({ data }) => {
+const ValidationsCalendar: React.FC<ValidationsCalendarProps> = ({ data }) => {
   if (!data || data.length === 0) return null;
 
-  
-    const lastDateStr = data.reduce((max, d) => (d.date > max ? d.date : max), data[0].date);
+  const lastDateStr = data.reduce((max, d) => (d.date > max ? d.date : max), data[0].date);
   const firstDateStr = data.reduce((min, d) => (d.date < min ? d.date : min), data[0].date);
   const lastDate = new Date(lastDateStr);
   const startDate = new Date(firstDateStr);
-
-  
 
   // Determine if range spans multiple years
   const firstYear = startDate.getFullYear();
@@ -41,34 +33,43 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({ data }) => 
   const years: number[] = [];
   for (let y = firstYear; y <= lastYear; y += 1) years.push(y);
 
+  // Fixed tile and SVG width for all years
+  const SQUARE = 12;
+  const GUTTER = 2;
+  const TOTAL_WEEKS = 53; // always 53 weeks for visual consistency
+  const FIXED_WIDTH = TOTAL_WEEKS * (SQUARE + GUTTER);
+
+
   const renderHeatmap = (year: number) => {
-    const SQUARE = 12;
-    const GUTTER = 3;
-    const yearStart = year === firstYear ? startDate : new Date(year, 0, 1);
-    const yearEnd = year === lastYear ? lastDate : new Date(year, 11, 31);
-    // number of weeks shown (inclusive)
-    const millisInWeek = 1000 * 60 * 60 * 24 * 7;
-    const weeks = Math.ceil((yearEnd.getTime() - yearStart.getTime()) / millisInWeek) + 1;
-    const svgWidth = weeks * (SQUARE + GUTTER);
-    const yearValues = data.filter((d) => new Date(d.date).getFullYear() === year);
+    const yearStart = new Date(year, 0, 1);
+    const yearEnd = new Date(year, 11, 31);
+    
+    const dataMap = new Map(data.map(d => [d.date, d.count]));
+
+    const fullYearData: CalendarDay[] = [];
+    for (let d = new Date(yearStart); d <= yearEnd; d.setDate(d.getDate() + 1)) {
+      const isoDate = d.toISOString().slice(0, 10);
+      fullYearData.push({
+        date: isoDate,
+        count: dataMap.get(isoDate) || 0,
+      });
+    }
+
     return (
-      <div key={year} className="mb-8">
+      <div key={year} className="mb-8" style={{ width: FIXED_WIDTH }}>
         {years.length > 1 && (
           <h4 className="text-lg font-semibold text-gray-700 mb-2">{year}</h4>
         )}
-        
         <Heatmap
           squareSize={SQUARE}
           gutterSize={GUTTER}
-          svgProps={{ width: svgWidth }}
-          
+          svgProps={{ width: FIXED_WIDTH, height: 90 }}
           showWeekdayLabels
           weekdayLabels={["Dg", "Dl", "Dt", "Dc", "Dj", "Dv", "Ds"]}
           monthLabels={["Gen", "Feb", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Oct", "Nov", "Des"]}
           startDate={yearStart}
           endDate={yearEnd}
-          values={yearValues as any}
-          
+          values={fullYearData as any}
           tooltipDataAttrs={(value: any) => {
             if (!value || !value.date) {
               return { 'data-tooltip-id': 'cal-tip', 'data-tooltip-content': '' };
@@ -78,6 +79,7 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({ data }) => 
             const monthNames = ["gener","febrer","març","abril","maig","juny","juliol","agost","setembre","octubre","novembre","desembre"];
             const monthName = monthNames[dateObj.getMonth()];
             const count = value.count || 0;
+
             return {
               'data-tooltip-id': 'cal-tip',
               'data-tooltip-content': `${count === 0 ? 'Sense validacions' : count + ' validacions'} el ${day} de ${monthName}`,
@@ -88,7 +90,7 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({ data }) => 
             const level = Math.min(4, value.count);
             return `color-scale-${level}`;
           }}
-          />
+        />
       </div>
     );
   };
@@ -101,9 +103,8 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({ data }) => 
         </h3>
       {years.map(renderHeatmap)}
       <Tooltip id="cal-tip" delayShow={0} />
-
     </div>
   );
 };
 
-export default ContributionCalendar;
+export default ValidationsCalendar;

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,41 @@
 @tailwind components;
 @tailwind utilities;
 
+.react-calendar-heatmap .color-empty {
+  fill: #ebedf0;
+}
+
+.react-calendar-heatmap .color-scale-1 {
+  fill: #9be9a8;
+}
+
+.react-calendar-heatmap .color-scale-2 {
+  fill: #40c463;
+}
+
+.react-calendar-heatmap .color-scale-3 {
+  fill: #30a14e;
+}
+
+.react-calendar-heatmap .color-scale-4 {
+  fill: #216e39;
+}
+
+/* Thin border around each day square */
+.react-calendar-heatmap rect {
+  stroke: #cbd5e1; /* Tailwind gray-300 */
+  stroke-width: 0.75;
+  rx: 2px;
+  ry: 2px;
+
+}
+
+/* Darker border on hover for visibility */
+.react-calendar-heatmap rect:hover {
+  stroke: #4a5568; /* Tailwind gray-700 */
+  stroke-width: 1;
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .scrollbar-hide::-webkit-scrollbar {
   display: none;

--- a/src/types/react-tooltip.d.ts
+++ b/src/types/react-tooltip.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-tooltip';

--- a/src/types/transport.ts
+++ b/src/types/transport.ts
@@ -15,4 +15,8 @@ export interface TransportSummary {
     agency: string;
     count: number;
   }>;
+  validationsByDay: Array<{
+    date: string;
+    count: number;
+  }>;
 }

--- a/src/utils/analyzeData.ts
+++ b/src/utils/analyzeData.ts
@@ -1,10 +1,9 @@
 import { TransportData, TransportSummary } from '../types/transport';
 
 export const analyzeTransportData = (data: TransportData[]): TransportSummary => {
-    const stationCount: { [key: string]: number } = {};
+  const stationCount: { [key: string]: number } = {};
   const agencyCount: { [key: string]: number } = {};
   const validationsByDayCount: { [key: string]: number } = {};
-  const agencyCount: { [key: string]: number } = {};
 
   // Count occurrences
   data.forEach((entry) => {

--- a/src/utils/analyzeData.ts
+++ b/src/utils/analyzeData.ts
@@ -1,7 +1,9 @@
 import { TransportData, TransportSummary } from '../types/transport';
 
 export const analyzeTransportData = (data: TransportData[]): TransportSummary => {
-  const stationCount: { [key: string]: number } = {};
+    const stationCount: { [key: string]: number } = {};
+  const agencyCount: { [key: string]: number } = {};
+  const validationsByDayCount: { [key: string]: number } = {};
   const agencyCount: { [key: string]: number } = {};
 
   // Count occurrences
@@ -11,6 +13,10 @@ export const analyzeTransportData = (data: TransportData[]): TransportSummary =>
     }
     if (entry.agency) {
       agencyCount[entry.agency] = (agencyCount[entry.agency] || 0) + 1;
+    }
+    if (entry.date) {
+      const dateString = entry.date.toISOString().split('T')[0];
+      validationsByDayCount[dateString] = (validationsByDayCount[dateString] || 0) + 1;
     }
   });
 
@@ -26,9 +32,15 @@ export const analyzeTransportData = (data: TransportData[]): TransportSummary =>
     .slice(0, 5)
     .map(([agency, count]) => ({ agency, count }));
 
+    const validationsByDay = Object.entries(validationsByDayCount).map(([date, count]) => ({
+    date,
+    count,
+  }));
+
   return {
     totalValidations: data.length,
     topStations,
-    topAgencies
+    topAgencies,
+    validationsByDay,
   };
 };


### PR DESCRIPTION
Inspirat en el heatmap de commits de Github, arriba el heatmap de validacions de la T-mobilitat.
- Es pot fer hover per veure en un dia en concret el nombre de validacions.
- He amagat el heatmap per a mobil ja que se sortia de la pantalla i tampoc tenia clar com era la millor forma de mostrar-lo.

Mostra:
<img width="847" height="310" alt="image" src="https://github.com/user-attachments/assets/7ed41250-a803-4dd8-b867-cd2a7fd25334" />

ps. he provat i la imatge que es descarrega per xarxes no es tant queda amb més espais laterals.. :sweat: 
ps2. per altre banda he provat de no mostrar les caselles de dies anteriors i posterios pero he tingut problemes perque llavors la mida no es mantenia (ho podem obrir com a issue)
