### PR TITLE
Canvi de html tags a tailwind classes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,8 +35,7 @@ function App() {
                   {error}
                 </p>
               )}
-              <br></br>
-              <center><p className="text-xs text-gray-500 mt-1">No guardem ni recollim aquestes dades</p></center>
+              <p className="text-xs text-gray-500 mt-4 text-center">No guardem ni recollim aquestes dades</p>
             </div>
 
             <HowTo />

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -93,8 +93,7 @@ export const Summary: React.FC<SummaryProps> = ({ summary }) => {
           </p>
         </div>
       </div>
-      <br></br>
-      <div className="flex justify-center">
+      <div className="flex justify-center mt-4">
         <button
           onClick={handleShare}
           className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-[#86c04d] to-[#009889] 


### PR DESCRIPTION
Aquesta PR elimina l'ús d'etiquetes HTML obsoletes i millora l'ús de Tailwind CSS.



